### PR TITLE
fix: incorrect hash in webpack production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Will generate the following HTML:
       scripts.forEach(function (scriptUrl) {
         var s = document.createElement("script");
         s.src = scriptUrl;
-        s.async = false; // preserve execution order.
+        s.async = false;
         document.body.appendChild(s);
       });
     </script>

--- a/src/csp.test.ts
+++ b/src/csp.test.ts
@@ -12,7 +12,7 @@ describe("Generate CSP directive set", () => {
     const strictCsp = csp.generateDirectiveSet(hashes);
 
     expect(strictCsp).toBe(
-      "base-uri 'self';object-src 'none';script-src 'strict-dynamic' 'sha256-i+xkhjPlTBs5uPQCVXqoKVd4vRPKE7xfcvCe+xg7U/0=';"
+      "base-uri 'self';object-src 'none';script-src 'strict-dynamic' 'sha256-mYdombCl/LUAKynRv79a3hlmGp7o1Dsd1wEeYRQb0NA=';"
     );
   });
 
@@ -23,7 +23,7 @@ describe("Generate CSP directive set", () => {
     const strictCsp = csp.generateDirectiveSet(hashes);
 
     expect(strictCsp).toBe(
-      "base-uri 'self';object-src 'none';script-src 'strict-dynamic' 'sha256-S4W5IfMGp/y53v/Xg551TrOjlh3QicY3LqXAnb8sfrc=' 'sha256-i+xkhjPlTBs5uPQCVXqoKVd4vRPKE7xfcvCe+xg7U/0=';"
+      "base-uri 'self';object-src 'none';script-src 'strict-dynamic' 'sha256-S4W5IfMGp/y53v/Xg551TrOjlh3QicY3LqXAnb8sfrc=' 'sha256-mYdombCl/LUAKynRv79a3hlmGp7o1Dsd1wEeYRQb0NA=';"
     );
   });
 
@@ -39,7 +39,7 @@ describe("Generate CSP directive set", () => {
     const strictCsp = csp.generateDirectiveSet(hashes);
 
     expect(strictCsp).toBe(
-      "base-uri 'self';object-src 'none';style-src 'self' 'unsafe-inline';script-src 'strict-dynamic' 'sha256-S4W5IfMGp/y53v/Xg551TrOjlh3QicY3LqXAnb8sfrc=' 'sha256-i+xkhjPlTBs5uPQCVXqoKVd4vRPKE7xfcvCe+xg7U/0=';"
+      "base-uri 'self';object-src 'none';style-src 'self' 'unsafe-inline';script-src 'strict-dynamic' 'sha256-S4W5IfMGp/y53v/Xg551TrOjlh3QicY3LqXAnb8sfrc=' 'sha256-mYdombCl/LUAKynRv79a3hlmGp7o1Dsd1wEeYRQb0NA=';"
     );
   });
 });

--- a/src/csp.ts
+++ b/src/csp.ts
@@ -106,7 +106,7 @@ export class Csp {
    *        scripts.forEach(function(scriptUrl) {
    *            var s = document.createElement('script');
    *            s.src = scriptUrl;
-   *            s.async = false; // preserve execution order.
+   *            s.async = false;
    *            document.body.appendChild(s);
    *        });
    *    </script>
@@ -120,15 +120,13 @@ export class Csp {
     }
 
     const srcListFormatted = scripts.map((s) => `'${s.src}'`).join();
-    return `
-    var scripts = [${srcListFormatted}];
+    return `var scripts = [${srcListFormatted}];
     scripts.forEach(function(scriptUrl) {
       var s = document.createElement('script');
       s.src = scriptUrl;
-      s.async = false; // preserve execution order.
+      s.async = false;
       document.body.appendChild(s);
-    });\n
-    `;
+    });\n`;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { Compiler, Compilation } from "webpack";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import { Csp, DirectiveSet } from "./csp";
+import webpack from "webpack";
 
 const pluginName = "CspHtmlWebpackPlugin";
 
@@ -44,6 +45,16 @@ export class CspHtmlWebpackPlugin {
 
   apply(compiler: Compiler): void {
     compiler.hooks.compilation.tap(pluginName, (compilation: Compilation) => {
+      // https://github.com/google/strict-csp/issues/48
+      compilation.hooks.processAssets.intercept({
+        register: (tap) => {
+          if (tap.name === "HtmlWebpackPlugin") {
+            tap.stage = webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT;
+          }
+          return tap;
+        },
+      });
+
       this.htmlWebpackPlugin
         .getHooks(compilation)
         .beforeEmit.tapAsync(


### PR DESCRIPTION
In applications created with tools like create-react-app, when building for production, the generated hashes may differ.